### PR TITLE
Separate prefix from body of number

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,6 +17,11 @@ Simply install the ~commify~ package.
 * Configuration
 Commify has several variables that you can set to alter its behaviour, either
 through the Emacs customize facility or with ~setq~'s in your init file.
+** Variables controlling all numbers
+The following variables affect how commify treats all numbers:
+
+- commify-group-prefix :: set non-nil to enable grouping prefixes from
+  numbers.  By default it is set to nil.
 
 ** Variables controlling decimal numbers
 The following variables affect how commify treats decimal numbers:

--- a/commify.el
+++ b/commify.el
@@ -76,6 +76,11 @@
   :type 'string
   :local t)
 
+(defcustom commify_group_prefix nil
+  "Whether to separate a prefix from a number."
+  :type 'boolean
+  :local t)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;; Decimal numbers customization
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -428,7 +433,10 @@ The matched sub-parts are:
             (replace-match (commify--commas
                             num commify-hex-group-char commify-hex-group-size
                             commify-hex-digits)
-                           t t nil 3))))
+                           t t nil 3)
+            (when commify_group_prefix
+              (replace-match (concat "\\2" commify-hex-group-char)
+                             t nil nil 2)))))
        ;; an octal number
        ((and commify-oct-enable (looking-at (commify--oct-number-re)))
         (let ((num (match-string 3)))
@@ -438,7 +446,10 @@ The matched sub-parts are:
             (replace-match (commify--commas
                             num commify-oct-group-char commify-oct-group-size
                             commify-oct-digits)
-                           t t nil 3))))
+                           t t nil 3)
+            (when commify_group_prefix
+              (replace-match (concat "\\2" commify-oct-group-char)
+                             t nil nil 2)))))
        ;; a binary number
        ((and commify-bin-enable (looking-at (commify--bin-number-re)))
         (let ((num (match-string 3)))
@@ -448,7 +459,10 @@ The matched sub-parts are:
             (replace-match (commify--commas
                             num commify-bin-group-char commify-bin-group-size
                             commify-bin-digits)
-                           t t nil 3))))
+                           t t nil 3)
+            (when commify_group_prefix
+              (replace-match (concat "\\2" commify-bin-group-char)
+                             t nil nil 2)))))
        ;; a decimal number, always enabled
        ((looking-at (commify--decimal-re))
         (let ((num (match-string 2)))


### PR DESCRIPTION
+ Uses the grouping delimiter to separate the prefix from the number

+ defcustom commify_group_prefix nil